### PR TITLE
 Switch to Thumb instruction set.

### DIFF
--- a/build.pl
+++ b/build.pl
@@ -18,11 +18,11 @@ sub ZipIt
 
 	# write build info
 	my $git_info = qx(git symbolic-ref -q HEAD && git rev-parse HEAD);
-	open(BUILD_INFO_FILE, '>', "obj/local/armeabi/build.txt") or die("Unable to write build information to build/temp/build.txt");
+	open(BUILD_INFO_FILE, '>', "obj/local/armeabi-v7a/build.txt") or die("Unable to write build information to build/temp/build.txt");
 	print BUILD_INFO_FILE "$git_info";
 	close(BUILD_INFO_FILE);
 
-	system("cd obj/local/armeabi && zip ../../../builds.zip -r *.a build.txt") && die("Failed to package libraries into zip file.");
+	system("cd obj/local/armeabi-v7a && zip ../../../builds.zip -r *.a build.txt") && die("Failed to package libraries into zip file.");
 }
 
 BuildAndroid();

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -6,4 +6,8 @@ LOCAL_MODULE    := krait-signal-handler
 LOCAL_SRC_FILES := krait_signal_handler.c
 LOCAL_CFLAGS    := -Wall -Werror
 
+ifeq ($(TARGET_ARCH_ABI), armeabi-v7a)
+    LOCAL_CFLAGS += -mthumb
+endif
+
 include $(BUILD_STATIC_LIBRARY)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,2 +1,3 @@
+APP_ABI := armeabi-v7a
 APP_PLATFORM := android-16
 NDK_TOOLCHAIN_VERSION := clang


### PR DESCRIPTION
Unity player has switched ARMv7 to Thumb instruction set. Maybe we should do the same with Mono? I need to discuss this with someone and run some tests so please don't merge this just yet.